### PR TITLE
Add Flask age prediction API skeleton

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# age-api
+# Age Prediction API
+
+This project provides a Flask based API for estimating the age of a face in an image using the **demoage** model. It is ready to be deployed on [Render](https://render.com/).
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running locally
+
+```bash
+python app.py
+```
+
+The server will start on port 5000.
+
+### Render
+
+Render will use the included `Procfile`. Simply create a new web service and point it to this repository.
+
+## Usage
+
+`POST /predict`
+
+Send an image either as a multipart/form-data file parameter named `image` or as JSON containing a base64 encoded string in the `image` field.
+
+**Example using curl with file:**
+```bash
+curl -X POST -F image=@face.jpg http://localhost:5000/predict
+```
+
+**Example using curl with base64 JSON:**
+```bash
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"image": "<base64 string>"}' http://localhost:5000/predict
+```
+
+The response will be:
+
+```json
+{ "age": 25 }
+```
+
+The `age` value is an integer predicted by the model.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,25 @@
+import base64
+from io import BytesIO
+from flask import Flask, request, jsonify
+
+from model import load_model, predict_age
+
+app = Flask(__name__)
+model = load_model()
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    img_bytes = None
+    if 'image' in request.files:
+        img_bytes = request.files['image'].read()
+    else:
+        data = request.get_json(force=True)
+        if not data or 'image' not in data:
+            return jsonify({'error': 'image is required'}), 400
+        img_bytes = base64.b64decode(data['image'])
+
+    age = predict_age(img_bytes, model)
+    return jsonify({'age': int(age)})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/model.py
+++ b/model.py
@@ -1,0 +1,40 @@
+import os
+import requests
+import torch
+from torchvision import transforms
+from PIL import Image
+from io import BytesIO
+
+WEIGHTS_URL = 'https://example.com/demoage.pt'
+WEIGHTS_PATH = 'demoage.pt'
+
+
+def download_weights():
+    if not os.path.exists(WEIGHTS_PATH):
+        resp = requests.get(WEIGHTS_URL, stream=True)
+        resp.raise_for_status()
+        with open(WEIGHTS_PATH, 'wb') as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+
+
+def load_model():
+    download_weights()
+    model = torch.jit.load(WEIGHTS_PATH, map_location=torch.device('cpu'))
+    model.eval()
+    return model
+
+
+_transform = transforms.Compose([
+    transforms.Resize((224, 224)),
+    transforms.ToTensor(),
+])
+
+
+def predict_age(image_bytes, model):
+    image = Image.open(BytesIO(image_bytes)).convert('RGB')
+    tensor = _transform(image).unsqueeze(0)
+    with torch.no_grad():
+        output = model(tensor)
+    return output.squeeze().item()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask
+torch
+torchvision
+pillow
+requests
+gunicorn


### PR DESCRIPTION
## Summary
- implement Flask server with `/predict` endpoint
- add model loading using demoage TorchScript weights
- document setup and usage
- specify dependencies and Render procfile

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68402e3b6c8c832b9f0b78bdaea61db8